### PR TITLE
fixes to work with allegro-5.2

### DIFF
--- a/allegro/acodec/c.go
+++ b/allegro/acodec/c.go
@@ -1,4 +1,4 @@
 package acodec
 
-// #cgo !windows pkg-config: allegro_acodec-5.0
+// #cgo !windows pkg-config: allegro_acodec-5
 import "C"

--- a/allegro/audio/c.go
+++ b/allegro/audio/c.go
@@ -1,4 +1,4 @@
 package audio
 
-// #cgo !windows pkg-config: allegro_audio-5.0
+// #cgo !windows pkg-config: allegro_audio-5
 import "C"

--- a/allegro/c.go
+++ b/allegro/c.go
@@ -1,6 +1,6 @@
 package allegro
 
-// #cgo !windows pkg-config: allegro-5.0
+// #cgo !windows pkg-config: allegro-5
 import "C"
 
 // Windows users should set the ALLEGRO_HOME environment variable

--- a/allegro/color/c.go
+++ b/allegro/color/c.go
@@ -1,4 +1,4 @@
 package color
 
-// #cgo !windows pkg-config: allegro_color-5.0
+// #cgo !windows pkg-config: allegro_color-5
 import "C"

--- a/allegro/dialog/c.go
+++ b/allegro/dialog/c.go
@@ -1,4 +1,4 @@
 package dialog
 
-// #cgo !windows pkg-config: allegro_dialog-5.0
+// #cgo !windows pkg-config: allegro_dialog-5
 import "C"

--- a/allegro/file.go
+++ b/allegro/file.go
@@ -86,7 +86,7 @@ func (f *File) Eof() bool {
 // Returns true if the error indicator is set on the given file, i.e. there was
 // some sort of previous error.
 func (f *File) HasError() bool {
-	return bool(C.al_ferror((*C.ALLEGRO_FILE)(f)))
+	return C.al_ferror((*C.ALLEGRO_FILE)(f)) != 0
 }
 
 // Clear the error indicator for the given file.

--- a/allegro/font/c.go
+++ b/allegro/font/c.go
@@ -1,4 +1,4 @@
 package font
 
-// #cgo !windows pkg-config: allegro_font-5.0
+// #cgo !windows pkg-config: allegro_font-5
 import "C"

--- a/allegro/font/ttf/c.go
+++ b/allegro/font/ttf/c.go
@@ -1,4 +1,4 @@
 package ttf
 
-// #cgo !windows pkg-config: allegro_ttf-5.0
+// #cgo !windows pkg-config: allegro_ttf-5
 import "C"

--- a/allegro/image/c.go
+++ b/allegro/image/c.go
@@ -1,4 +1,4 @@
 package image
 
-// #cgo !windows pkg-config: allegro_image-5.0
+// #cgo !windows pkg-config: allegro_image-5
 import "C"

--- a/allegro/memfile/c.go
+++ b/allegro/memfile/c.go
@@ -1,4 +1,4 @@
 package memfile
 
-// #cgo !windows pkg-config: allegro_memfile-5.0
+// #cgo !windows pkg-config: allegro_memfile-5
 import "C"

--- a/allegro/physfs/c.go
+++ b/allegro/physfs/c.go
@@ -1,4 +1,4 @@
 package physfs
 
-// #cgo !windows pkg-config: allegro_physfs-5.0
+// #cgo !windows pkg-config: allegro_physfs-5
 import "C"

--- a/allegro/primitives/c.go
+++ b/allegro/primitives/c.go
@@ -1,4 +1,4 @@
 package primitives
 
-// #cgo !windows pkg-config: allegro_primitives-5.0
+// #cgo !windows pkg-config: allegro_primitives-5
 import "C"

--- a/allegro/tiled/c.go
+++ b/allegro/tiled/c.go
@@ -1,4 +1,4 @@
 package tiled
 
-// #cgo !windows pkg-config: allegro_tiled-5.0
+// #cgo !windows pkg-config: allegro_tiled-5
 import "C"

--- a/documenter.go
+++ b/documenter.go
@@ -5,7 +5,7 @@ package main
 
 import (
 	"bytes"
-	"code.google.com/p/go.net/html"
+	"golang.org/x/net/html"
 	"container/list"
 	"flag"
 	"fmt"


### PR DESCRIPTION
I had two issues trying to get this library to work and run the examples.

First, documenter.go wouldn't build because the go.net/html dependency couldn't be resolved. I updated the import path accordingly.

Second, https://github.com/liballeg/allegro5/commit/2852b07a92f0cb6c6fcff77221db56e203a850df changed the return type of the al_ferror() function from bool to int in allegro, with values !=0 indicating an error condition, so I updated the HasError() method accordingly.