### PR TITLE
fixed an html package import

### DIFF
--- a/documenter.go
+++ b/documenter.go
@@ -5,7 +5,7 @@ package main
 
 import (
 	"bytes"
-	"code.google.com/p/go.net/html"
+	"golang.org/x/net/html"
 	"container/list"
 	"flag"
 	"fmt"


### PR DESCRIPTION
The package at code.google.com/p/go.net/html no longer exists.
