### PR TITLE
Fix argument list for allegro.SetSeparateBlender()

### DIFF
--- a/allegro/graphics.go
+++ b/allegro/graphics.go
@@ -249,7 +249,7 @@ func SetBlender(op BlendingOperation, src, dst BlendingValue) {
 // the alpha channel. This is useful if your target bitmap also has an alpha
 // channel and the two alpha channels need to be combined in a different way
 // than the color components.
-func SetSeparateBlender(op BlendingOperation, src, dst, BlendingValue, alpha_op BlendingOperation, alpha_src, alpha_dst BlendingValue) {
+func SetSeparateBlender(op BlendingOperation, src, dst BlendingValue, alpha_op BlendingOperation, alpha_src, alpha_dst BlendingValue) {
 	C.al_set_separate_blender(
 		C.int(op),
 		C.int(src),


### PR DESCRIPTION
Fix argument list for `allegro.SetSeparateBlender()`

This function is meant to accept six arguments:

```
allegro.BlendingOperation
allegro.BlendingValue
allegro.BlendingValue
allegro.BlendingOperation
allegro.BlendingValue
allegro.BlendingValue
```

However, a typo (extra comma) defined the function to accept seven arguments:

```
allegro.BlendingOperation
allegro.BlendingOperation
allegro.BlendingOperation
allegro.BlendingOperation
allegro.BlendingOperation
allegro.BlendingValue
allegro.BlendingValue
```